### PR TITLE
Themes: Use default audibles when pkgName is empty

### DIFF
--- a/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
+++ b/cm/lib/main/java/org/cyanogenmod/platform/internal/ThemeManagerService.java
@@ -632,7 +632,7 @@ public class ThemeManagerService extends CMSystemService {
     private boolean updateAudible(String dirPath, String assetPath, int type, String pkgName) {
         //Clear the dir
         ThemeUtils.clearAudibles(mContext, dirPath);
-        if (pkgName.equals(SYSTEM_DEFAULT)) {
+        if (TextUtils.isEmpty(pkgName) || pkgName.equals(SYSTEM_DEFAULT)) {
             if (!ThemeUtils.setDefaultAudible(mContext, type)) {
                 Log.e(TAG, "There was an error installing the default audio file");
                 return false;


### PR DESCRIPTION
Fixes an issue where audibles would be "unknown" causing them to
not play when phone rings, notifications arive or an alarm goes off

Change-Id: If279ed7e88784c025999822da7ee3a1a51d63bbd
TICKET: CYNGNOS-2728